### PR TITLE
in archive templates, rename items to the post type plural name (came…

### DIFF
--- a/@jambaree/next-wordpress/index.ts
+++ b/@jambaree/next-wordpress/index.ts
@@ -19,6 +19,11 @@ export { getOptionsPage } from "./src/api/get-options-page";
 export { FlexibleContent } from "./src/components/flexible-content";
 export { WordpressTemplate } from "./src/components/wordpress-template/wordpress-template";
 
+// utils helpers
+export { getFeaturedImage } from "./src/utils/get-featured-image";
+export { stripWpUrl } from "./src/utils/strip-wp-url";
+export { swapWpUrl } from "./src/utils/swap-wp-url";
+
 // deprecated functions
 export const getData = () => {
   throw new Error(

--- a/@jambaree/next-wordpress/package.json
+++ b/@jambaree/next-wordpress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jambaree/next-wordpress",
-  "version": "2.0.0-beta.34",
+  "version": "2.0.0-beta.35",
   "dependencies": {
     "@types/node": "^20.8.10",
     "@types/react": "^18.2.33",

--- a/@jambaree/next-wordpress/src/api/get-auth-headers.ts
+++ b/@jambaree/next-wordpress/src/api/get-auth-headers.ts
@@ -1,0 +1,8 @@
+export function getAuthHeaders(): HeadersInit | undefined {
+  if (!process.env.WP_APPLICATION_PASSWORD) {
+    return;
+  }
+  return {
+    Authorization: `Basic ${btoa(process.env.WP_APPLICATION_PASSWORD)}`,
+  };
+}

--- a/@jambaree/next-wordpress/src/api/get-options-page.ts
+++ b/@jambaree/next-wordpress/src/api/get-options-page.ts
@@ -1,3 +1,5 @@
+import { getAuthHeaders } from "./get-auth-headers";
+
 type OptionsPageResponse = {
   code?: string;
   message?: string;
@@ -39,9 +41,7 @@ You can generate an application password in your WordPress admin under Users > Y
   const req = await fetch(
     `${process.env.NEXT_PUBLIC_WP_URL}/wp-json/jambaree/v1/options/${slug}`,
     {
-      headers: {
-        Authorization: `Basic ${btoa(process.env.WP_APPLICATION_PASSWORD)}`,
-      },
+      headers: getAuthHeaders(),
     }
   );
   let data;

--- a/@jambaree/next-wordpress/src/api/get-post-types.ts
+++ b/@jambaree/next-wordpress/src/api/get-post-types.ts
@@ -1,3 +1,5 @@
+import { getAuthHeaders } from "./get-auth-headers";
+
 export type PostType = {
   /**
    * `false` if no archive, `string` if archive slug is different from post type slug
@@ -34,11 +36,15 @@ type PostTypesResponse = {
  */
 export async function getPostTypes(): Promise<PostTypes> {
   const req = await fetch(
-    `${process.env.NEXT_PUBLIC_WP_URL}/wp-json/wp/v2/types`
+    `${process.env.NEXT_PUBLIC_WP_URL}/wp-json/wp/v2/types?context=edit`,
+    {
+      headers: getAuthHeaders(),
+    }
   );
 
   try {
     const data = (await req.json()) as PostTypesResponse;
+
     return data;
   } catch (err) {
     throw new Error(`getPostTypes: Error fetching post types: ${err.message}`);

--- a/@jambaree/next-wordpress/src/api/get-site-settings.ts
+++ b/@jambaree/next-wordpress/src/api/get-site-settings.ts
@@ -1,4 +1,5 @@
 import type { WpSettings } from "@/types";
+import { getAuthHeaders } from "./get-auth-headers";
 
 type WpSettingsResponse = {
   code?: string;
@@ -29,9 +30,7 @@ ${
   const req = await fetch(
     `${process.env.NEXT_PUBLIC_WP_URL}/wp-json/wp/v2/settings?embed=true`,
     {
-      headers: {
-        Authorization: `Basic ${btoa(process.env.WP_APPLICATION_PASSWORD)}`,
-      },
+      headers: getAuthHeaders(),
     }
   );
 

--- a/@jambaree/next-wordpress/src/components/wordpress-template/page-template-loader.tsx
+++ b/@jambaree/next-wordpress/src/components/wordpress-template/page-template-loader.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { notFound } from "next/navigation";
 import { draftMode } from "next/headers";
+import { createDataProxy } from "../../helpers/data-proxy";
 import getTemplate from "../../utils/get-template";
 import { getPageData } from "../../api/get-page-data";
 import { PreviewToolbar } from "../preview-toolbar";
@@ -48,6 +49,10 @@ export default async function PageTemplateLoader(props: {
     });
   }
 
+  // Create a proxy to log warnings when user is accessing deprecated data keys
+  const preppedData =
+    archive && mergedData ? createDataProxy(mergedData) : mergedData;
+
   return (
     <>
       {process.env.ROUTE_PARAMS_DEBUG_ENABLED ? (
@@ -56,7 +61,7 @@ export default async function PageTemplateLoader(props: {
 
       <PageTemplate
         archive={archive}
-        data={mergedData}
+        data={preppedData}
         isPreview={preview.isEnabled}
         uri={uri}
         {...props}

--- a/@jambaree/next-wordpress/src/helpers/data-proxy.ts
+++ b/@jambaree/next-wordpress/src/helpers/data-proxy.ts
@@ -1,0 +1,15 @@
+// This function creates a proxy for your data object
+export function createDataProxy(data: any): any {
+  return new Proxy(data, {
+    get(target, property) {
+      if (property === "items") {
+        // eslint-disable-next-line no-console -- this is a warning for deprecated usage
+        console.warn(
+          `⚠️ Warning: Using 'data.items' key in archive templates is deprecated.
+  Please use the posts plural_name key instead. This will usually be the plural_name of the post type, converted to camelCase.`
+        );
+      }
+      return target[property];
+    },
+  });
+}

--- a/@jambaree/next-wordpress/src/utils/to-camel.ts
+++ b/@jambaree/next-wordpress/src/utils/to-camel.ts
@@ -1,0 +1,5 @@
+export function toCamel(str: string): string {
+  return str.replace(/(?<temp1>[-_][a-z])/gi, ($1) => {
+    return $1.toUpperCase().replace("-", "").replace("_", "");
+  });
+}

--- a/next-wordpress-starter/src/templates/archive/blog.tsx
+++ b/next-wordpress-starter/src/templates/archive/blog.tsx
@@ -6,10 +6,11 @@ import Edges from "@/components/edges";
 import Button from "@/components/ui/button";
 
 export default function PostArchive(props) {
+  // console.log(props);
   const {
     // uri,
     data: {
-      items,
+      posts,
       page,
       prevPage,
       nextPage,
@@ -20,14 +21,15 @@ export default function PostArchive(props) {
     // archive,
   } = props;
 
+  // console.log({ items });
   return (
     <div>
-      <h1>items: {items.length}</h1>
+      <h1>items: {posts.length}</h1>
 
       <Edges>
         <h1 className="mb-5">{page?.title?.rendered}</h1>
         <div className="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-3">
-          {items.map((post) => {
+          {posts.map((post) => {
             const featuredImage = getFeaturedImage(post);
             return (
               <article


### PR DESCRIPTION
…lCased)

- logs deprecation warning for anyone still using "items" in archive template.
- export util helpers from index. (getFeaturedImage, stripWpUrl, swapWpUrl)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206186754301244